### PR TITLE
lib: Add boost_spirit x3 to build

### DIFF
--- a/cmake/Conan.cmake
+++ b/cmake/Conan.cmake
@@ -20,6 +20,7 @@ macro(run_conan)
     docopt.cpp/0.6.2
     fmt/6.2.0
     spdlog/1.5.0
+    boost_spirit/1.69.0@bincrafters/stable
     OPTIONS
     ${CONAN_EXTRA_OPTIONS}
     BASIC_SETUP

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -6,4 +6,5 @@ target_link_libraries(
           project_warnings
           CONAN_PKG::docopt.cpp
           CONAN_PKG::fmt
-          CONAN_PKG::spdlog)
+          CONAN_PKG::spdlog
+          CONAN_PKG::boost_spirit)

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -4,6 +4,7 @@
 
 #include <spdlog/spdlog.h>
 #include <docopt/docopt.h>
+#include <boost/spirit/home/x3.hpp>
 
 #include "util/args.h"
 


### PR DESCRIPTION
 - Add boost_spirit/1.69.0 to build dependency for roll parsing

This is to parse rolls (i.e. "4d3", "1d6", "2 + 1d6") from the commandline